### PR TITLE
Susfs: Bump version to v1.5.12 for 4.19 kernel

### DIFF
--- a/.github/workflows/patch-susfs/action.yml
+++ b/.github/workflows/patch-susfs/action.yml
@@ -235,6 +235,15 @@ runs:
             echo "Your kernelsu fork cannot supported SuSFS 1.5.11, Skipped."
           fi
 
+          # Upgrade 1.5.12
+          cp /tmp/Patches/Patch/susfs_upgrade_to_1512_${{ env.KERNEL_VERSION }}.patch ./
+          patch -p1 < susfs_upgrade_to_1512_${{ env.KERNEL_VERSION }}.patch || true
+          echo "================="
+          echo "=Upgraded 1.5.12="
+          echo "================="
+
+          REJ_FOUND "1.5.12"
+
       - name: Updated SUSFS Patch Fixed
         if: env.SUSFS_ENABLE == 'true' && env.SUSFS_UPDATE == 'true' && env.SUSFS_SKIP != 'true'
         shell: bash

--- a/Patches/Patch/susfs_upgrade_to_1512_4.19.patch
+++ b/Patches/Patch/susfs_upgrade_to_1512_4.19.patch
@@ -1,0 +1,1146 @@
+diff --color -uNr a/fs/namespace.c b/fs/namespace.c
+--- a/fs/namespace.c	2025-10-27 03:49:34.000000000 +0800
++++ b/fs/namespace.c	2025-10-27 13:10:03.000000000 +0800
+@@ -38,7 +38,6 @@
+ extern bool susfs_is_current_zygote_domain(void);
+ extern bool susfs_is_boot_completed_triggered;
+ 
+-static DEFINE_IDA(susfs_ksu_mnt_id_ida);
+ static DEFINE_IDA(susfs_ksu_mnt_group_ida);
+ 
+ #define CL_COPY_MNT_NS BIT(25) /* used by copy_mnt_ns() */
+@@ -49,7 +48,7 @@
+ bool susfs_is_auto_add_sus_ksu_default_mount_enabled = true;
+ #endif
+ #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT
+-extern int susfs_auto_add_sus_bind_mount(const char *pathname, struct path *path_target);
++extern void susfs_auto_add_sus_bind_mount(const char *pathname, struct path *path_target);
+ bool susfs_is_auto_add_sus_bind_mount_enabled = true;
+ #endif
+ #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_TRY_UMOUNT_FOR_BIND_MOUNT
+@@ -123,18 +122,6 @@
+ 	return &mountpoint_hashtable[tmp & mp_hash_mask];
+ }
+ 
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-// Our own mnt_alloc_id() that assigns mnt_id starting from DEFAULT_KSU_MNT_ID
+-static int susfs_mnt_alloc_id(struct mount *mnt)
+-{
+-	int res = ida_alloc_min(&susfs_ksu_mnt_id_ida, DEFAULT_KSU_MNT_ID, GFP_KERNEL);
+-
+-	if (res < 0)
+-		return res;
+-	mnt->mnt_id = res;
+-	return 0;
+-}
+-#endif
+ static int mnt_alloc_id(struct mount *mnt)
+ {
+ 	int res = ida_alloc(&mnt_id_ida, GFP_KERNEL);
+@@ -148,24 +135,18 @@
+ static void mnt_free_id(struct mount *mnt)
+ {
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	// We should first check the 'mnt->mnt.susfs_mnt_id_backup', see if it is DEFAULT_KSU_MNT_ID_FOR_KSU_PROC_UNSHARE
+-	// if so, these mnt_id were not assigned by mnt_alloc_id() so we don't need to free it.
+-	if (unlikely(mnt->mnt.susfs_mnt_id_backup == DEFAULT_KSU_MNT_ID_FOR_KSU_PROC_UNSHARE)) {
++	// First we have to check if susfs_mnt_id_backup == DEFAULT_KSU_MNT_ID,
++	// if so, no need to free.
++	if (mnt->mnt.susfs_mnt_id_backup == DEFAULT_KSU_MNT_ID) {
+ 		return;
+ 	}
+-	// Now we can check if its mnt_id is sus
+-	if (unlikely(mnt->mnt_id >= DEFAULT_KSU_MNT_ID)) {
+-		ida_free(&susfs_ksu_mnt_id_ida, mnt->mnt_id);
+-		return;
+-	}
+-	// Lastly if 'mnt->mnt.susfs_mnt_id_backup' is not 0, then it contains a backup origin mnt_id
+-	// so we free it in the original way
++
++	// Second if susfs_mnt_id_backup was set after mnt_id reorder, free it if so.
+ 	if (likely(mnt->mnt.susfs_mnt_id_backup)) {
+-		// If mnt->mnt.susfs_mnt_id_backup is not zero, it means mnt->mnt_id is spoofed,
+-		// so here we return the original mnt_id for being freed.
+ 		ida_free(&mnt_id_ida, mnt->mnt.susfs_mnt_id_backup);
+ 		return;
+ 	}
++
+ #endif
+ 	ida_free(&mnt_id_ida, mnt->mnt_id);
+ }
+@@ -178,9 +159,12 @@
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+ 	int res;
+ 
+-	// Check if mnt has sus mnt_id
+-	if (mnt->mnt_id >= DEFAULT_KSU_MNT_ID) {
+-		// If so, assign a sus mnt_group id DEFAULT_KSU_MNT_GROUP_ID from susfs_ksu_mnt_group_ida
++	/* - At frist susfs_is_boot_completed_triggered is set to false in kernel,
++	 *   and it is still allowed to assign our custom mnt_group_id via susfs_ksu_mnt_group_ida
++	 *   if it is ksu mounts, until susfs_is_boot_completed_triggered is set to true
++	 *   when boot-completed stage is triggered in core_hook.c 
++	 */
++	if (!susfs_is_boot_completed_triggered && mnt->mnt_id >= DEFAULT_KSU_MNT_ID) {
+ 		res = ida_alloc_min(&susfs_ksu_mnt_group_ida, DEFAULT_KSU_MNT_GROUP_ID, GFP_KERNEL);
+ 		goto bypass_orig_flow;
+ 	}
+@@ -202,9 +186,16 @@
+ void mnt_release_group_id(struct mount *mnt)
+ {
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	// If mnt->mnt_group_id >= DEFAULT_KSU_MNT_GROUP_ID, it means 'mnt' is also sus mount,
+-	// then we free the mnt->mnt_group_id from susfs_ksu_mnt_group_ida
+-	if (mnt->mnt_group_id >= DEFAULT_KSU_MNT_GROUP_ID) {
++	/* - when boot-completed stage is triggered in core_hook.c,
++	 *   susfs_is_boot_completed_triggered will be set to true.
++	 * - Please note that if susfs_is_boot_completed_triggered is true, then
++	 *   it no longer checks for the sus mnt_group_id, and the allocated
++	 *   sus mnt_group_id will stay in kernel memory forever, and if user
++	 *   suddenly umounts the sus mount in global mnt namespace, the ida_free()
++	 *   function will throw error to kernel log, but it won't affect the system,
++	 *   so it is fine.
++	 */
++	if (!susfs_is_boot_completed_triggered && mnt->mnt_group_id >= DEFAULT_KSU_MNT_GROUP_ID) {
+ 		ida_free(&susfs_ksu_mnt_group_ida, mnt->mnt_group_id);
+ 		mnt->mnt_group_id = 0;
+ 		return;
+@@ -256,30 +247,119 @@
+ }
+ 
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-static struct mount *alloc_vfsmnt(const char *name, bool should_spoof, int custom_mnt_id)
++/* A copy of alloc_vfsmnt() but reuse the original mnt_id to mnt */
++static struct mount *susfs_reuse_sus_vfsmnt(const char *name, int orig_mnt_id)
++{
++	struct mount *mnt = kmem_cache_zalloc(mnt_cache, GFP_KERNEL);
++	if (mnt) {
++		mnt->mnt_id = orig_mnt_id;
++
++		if (name) {
++			mnt->mnt_devname = kstrdup_const(name,
++							 GFP_KERNEL_ACCOUNT);
++			if (!mnt->mnt_devname)
++				goto out_free_cache;
++		}
++
++#ifdef CONFIG_SMP
++		mnt->mnt_pcp = alloc_percpu(struct mnt_pcp);
++		if (!mnt->mnt_pcp)
++			goto out_free_devname;
++
++		this_cpu_add(mnt->mnt_pcp->mnt_count, 1);
+ #else
+-static struct mount *alloc_vfsmnt(const char *name)
++		mnt->mnt_count = 1;
++		mnt->mnt_writers = 0;
++#endif
++		mnt->mnt.data = NULL;
++
++		// Makes ida_free() easier to determine whether it should free the mnt_id or not
++		mnt->mnt.susfs_mnt_id_backup = DEFAULT_KSU_MNT_ID;
++
++		INIT_HLIST_NODE(&mnt->mnt_hash);
++		INIT_LIST_HEAD(&mnt->mnt_child);
++		INIT_LIST_HEAD(&mnt->mnt_mounts);
++		INIT_LIST_HEAD(&mnt->mnt_list);
++		INIT_LIST_HEAD(&mnt->mnt_expire);
++		INIT_LIST_HEAD(&mnt->mnt_share);
++		INIT_LIST_HEAD(&mnt->mnt_slave_list);
++		INIT_LIST_HEAD(&mnt->mnt_slave);
++		INIT_HLIST_NODE(&mnt->mnt_mp_list);
++		INIT_LIST_HEAD(&mnt->mnt_umounting);
++		init_fs_pin(&mnt->mnt_umount, drop_mountpoint);
++	}
++	return mnt;
++
++#ifdef CONFIG_SMP
++out_free_devname:
++	kfree_const(mnt->mnt_devname);
+ #endif
++out_free_cache:
++	kmem_cache_free(mnt_cache, mnt);
++	return NULL;
++}
++#endif
++
++#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
++/* A copy of alloc_vfsmnt() but allocates the fake mnt_id to mnt */
++static struct mount *susfs_alloc_sus_vfsmnt(const char *name)
+ {
+ 	struct mount *mnt = kmem_cache_zalloc(mnt_cache, GFP_KERNEL);
+ 	if (mnt) {
+-		int err;
++		mnt->mnt_id = DEFAULT_KSU_MNT_ID;
+ 
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-		if (should_spoof) {
+-			if (!custom_mnt_id) {
+-				err = susfs_mnt_alloc_id(mnt);
+-			} else {
+-				mnt->mnt_id = custom_mnt_id;
+-				err = 0;
+-			}
+-			goto bypass_orig_flow;
++		if (name) {
++			mnt->mnt_devname = kstrdup_const(name,
++							 GFP_KERNEL_ACCOUNT);
++			if (!mnt->mnt_devname)
++				goto out_free_cache;
+ 		}
++
++#ifdef CONFIG_SMP
++		mnt->mnt_pcp = alloc_percpu(struct mnt_pcp);
++		if (!mnt->mnt_pcp)
++			goto out_free_devname;
++
++		this_cpu_add(mnt->mnt_pcp->mnt_count, 1);
++#else
++		mnt->mnt_count = 1;
++		mnt->mnt_writers = 0;
+ #endif
+-		err = mnt_alloc_id(mnt);
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-bypass_orig_flow:
++		mnt->mnt.data = NULL;
++		// Makes ida_free() easier to determine whether it should free the mnt_id or not
++		mnt->mnt.susfs_mnt_id_backup = DEFAULT_KSU_MNT_ID;
++
++		INIT_HLIST_NODE(&mnt->mnt_hash);
++		INIT_LIST_HEAD(&mnt->mnt_child);
++		INIT_LIST_HEAD(&mnt->mnt_mounts);
++		INIT_LIST_HEAD(&mnt->mnt_list);
++		INIT_LIST_HEAD(&mnt->mnt_expire);
++		INIT_LIST_HEAD(&mnt->mnt_share);
++		INIT_LIST_HEAD(&mnt->mnt_slave_list);
++		INIT_LIST_HEAD(&mnt->mnt_slave);
++		INIT_HLIST_NODE(&mnt->mnt_mp_list);
++		INIT_LIST_HEAD(&mnt->mnt_umounting);
++		init_fs_pin(&mnt->mnt_umount, drop_mountpoint);
++	}
++	return mnt;
++
++#ifdef CONFIG_SMP
++out_free_devname:
++	kfree_const(mnt->mnt_devname);
+ #endif
++out_free_cache:
++	kmem_cache_free(mnt_cache, mnt);
++	return NULL;
++}
++#endif
++
++static struct mount *alloc_vfsmnt(const char *name)
++{
++	struct mount *mnt = kmem_cache_zalloc(mnt_cache, GFP_KERNEL);
++	if (mnt) {
++		int err;
++
++		err = mnt_alloc_id(mnt);
+ 		if (err)
+ 			goto out_free_cache;
+ 
+@@ -300,6 +380,10 @@
+ 		mnt->mnt_writers = 0;
+ #endif
+ 		mnt->mnt.data = NULL;
++#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
++		// Make sure mnt->mnt.susfs_mnt_id_backup is initialized every time.
++		mnt->mnt.susfs_mnt_id_backup = 0;
++#endif
+ 
+ 		INIT_HLIST_NODE(&mnt->mnt_hash);
+ 		INIT_LIST_HEAD(&mnt->mnt_child);
+@@ -1048,26 +1132,22 @@
+ {
+ 	struct mount *mnt;
+ 	struct dentry *root;
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	struct mount *m;
+-	struct mnt_namespace *mnt_ns;
+-	int mnt_id;
+-#endif
+ 
+ 	if (!type)
+ 		return ERR_PTR(-ENODEV);
+ 
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	// For newly created mounts, the only caller process we care is KSU
+-	if (unlikely(susfs_is_current_ksu_domain())) {
+-		mnt = alloc_vfsmnt(name, true, 0);
+-		goto bypass_orig_flow;
+-	}
+-	mnt = alloc_vfsmnt(name, false, 0);
++    // We only check for ksu process
++        if (susfs_is_current_ksu_domain()) {
++                mnt = susfs_alloc_sus_vfsmnt(name);
++                goto bypass_orig_flow;
++        }
++#endif
++         mnt = alloc_vfsmnt(name);
++#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+ bypass_orig_flow:
+-#else
+-	mnt = alloc_vfsmnt(name);
+ #endif
++
+ 	if (!mnt)
+ 		return ERR_PTR(-ENOMEM);
+ 
+@@ -1094,28 +1174,6 @@
+ 	mnt->mnt_mountpoint = mnt->mnt.mnt_root;
+ 	mnt->mnt_parent = mnt;
+ 
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	// - If caller process is zygote, then it is a normal mount, so we calculate the next available
+-	//   fake mnt_id for this mount
+-	if (susfs_is_current_zygote_domain()) {
+-		mnt_ns = current->nsproxy->mnt_ns;
+-		if (mnt_ns) {
+-			get_mnt_ns(mnt_ns);
+-			rcu_read_lock();
+-			mnt_id = list_first_entry(&mnt_ns->list, struct mount, mnt_list)->mnt_id;
+-			list_for_each_entry_rcu(m, &mnt_ns->list, mnt_list) {
+-				if (m->mnt_id < DEFAULT_KSU_MNT_ID) {
+-					mnt_id++;
+-				}
+-			}
+-			WRITE_ONCE(mnt->mnt.susfs_mnt_id_backup, READ_ONCE(mnt->mnt_id));
+-			WRITE_ONCE(mnt->mnt_id, READ_ONCE(mnt_id));
+-			rcu_read_unlock();
+-			put_mnt_ns(mnt_ns);
+-		}
+-	}
+-#endif
+-
+ 	lock_mount_hash();
+ 	list_add_tail(&mnt->mnt_instance, &root->d_sb->s_mounts);
+ 	unlock_mount_hash();
+@@ -1146,45 +1204,34 @@
+ 	int err;
+ 
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	struct mount *m;
+-	struct mnt_namespace *mnt_ns;
+-	int mnt_id;
+-
+-	bool is_current_ksu_domain = susfs_is_current_ksu_domain();
+-	bool is_current_zygote_domain = susfs_is_current_zygote_domain();
++	// - We do not check anymore for ksu process if boot-completed stage is triggered
++	//   just to stop the performance loss
++	if (susfs_is_boot_completed_triggered) {
++		goto skip_checking_for_ksu_proc;
++	}
+ 
+-	/* - It is very important that we need to use CL_COPY_MNT_NS to identify whether
+-	 *   the clone is a copy_tree() or single mount like called by __do_loopback()
+-	 * - if caller process is KSU, consider the following situation:
+-	 *     1. it is NOT doing unshare => call alloc_vfsmnt() to assign a new sus mnt_id
+-	 *     2. it is doing unshare => spoof the new mnt_id with the old mnt_id * - For the rest of caller process with sus old->mnt_id => call alloc_vfsmnt() to assign a new sus mnt_id
+-	 * - Important notes: Here we can't determine whether the unshare is called by zygisk or not,
+-	 *   so we can only patch out the unshare code in zygisk source code for now,
+-	 *   but at least we can deal with old sus mounts using alloc_vfsmnt()
+-	 */
+-	// Firstly, check if it is KSU process
+-	if (unlikely(is_current_ksu_domain)) {
+-		// if it is doing single clone
+-		if (!(flag & CL_COPY_MNT_NS)) {
+-			mnt = alloc_vfsmnt(old->mnt_devname, true, 0);
++	// First we must check for ksu process because of magic mount
++	if (susfs_is_current_ksu_domain()) {
++		// if it is unsharing, we reuse the old->mnt_id
++		if (flag & CL_COPY_MNT_NS) {
++			mnt = susfs_reuse_sus_vfsmnt(old->mnt_devname, old->mnt_id);
+ 			goto bypass_orig_flow;
+ 		}
+-		// if it is doing unshare
+-		mnt = alloc_vfsmnt(old->mnt_devname, true, old->mnt_id);
+-		if (mnt) {
+-			mnt->mnt.susfs_mnt_id_backup = DEFAULT_KSU_MNT_ID_FOR_KSU_PROC_UNSHARE;
+-		}
++		// else we just go assign fake mnt_id
++		mnt = susfs_alloc_sus_vfsmnt(old->mnt_devname);
+ 		goto bypass_orig_flow;
+ 	}
+-	// Lastly, just check if old->mnt_id is sus
+-	if (old->mnt_id >= DEFAULT_KSU_MNT_ID) {
+-		mnt = alloc_vfsmnt(old->mnt_devname, true, 0);
++
++skip_checking_for_ksu_proc:
++	// Lastly for other processes of which old->mnt_id == DEFAULT_KSU_MNT_ID, go assign fake mnt_id
++	if (old->mnt_id == DEFAULT_KSU_MNT_ID) {
++		mnt = susfs_alloc_sus_vfsmnt(old->mnt_devname);
+ 		goto bypass_orig_flow;
+ 	}
+-	mnt = alloc_vfsmnt(old->mnt_devname, false, 0);
+-bypass_orig_flow:
+-#else
++#endif
+ 	mnt = alloc_vfsmnt(old->mnt_devname);
++#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
++bypass_orig_flow:
+ #endif
+ 	if (!mnt)
+ 		return ERR_PTR(-ENOMEM);
+@@ -1238,31 +1285,6 @@
+ 	mnt->mnt_mountpoint = mnt->mnt.mnt_root;
+ 	mnt->mnt_parent = mnt;
+ 
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	// - If caller process is zygote, then it is a normal mount, so we calculate the next available
+-	//   fake mnt_id for this mount, but there is one situation that the previous clone_mnt is not
+-	//   yet attached to the current mnt_ns during copy_tree() so that it will fail to calculate
+-	//   the correct fake mnt_id.
+-	// - Currently we have a tmep fix for this in copy_tree(), but maybe not reliable for other devices
+-	if (likely(is_current_zygote_domain) && !(flag & CL_COPY_MNT_NS)) {
+-		mnt_ns = current->nsproxy->mnt_ns;
+-		if (mnt_ns) {
+-			get_mnt_ns(mnt_ns);
+-			rcu_read_lock();
+-			mnt_id = list_first_entry(&mnt_ns->list, struct mount, mnt_list)->mnt_id;
+-			list_for_each_entry_rcu(m, &mnt_ns->list, mnt_list) {
+-				if (m->mnt_id < DEFAULT_KSU_MNT_ID) {
+-					mnt_id++;
+-				}
+-			}
+-			WRITE_ONCE(mnt->mnt.susfs_mnt_id_backup, READ_ONCE(mnt->mnt_id));
+-			WRITE_ONCE(mnt->mnt_id, READ_ONCE(mnt_id));
+-			rcu_read_unlock();
+-			put_mnt_ns(mnt_ns);
+-		}
+-	}
+-#endif
+-
+ 	lock_mount_hash();
+ 	list_add_tail(&mnt->mnt_instance, &sb->s_mounts);
+ 	unlock_mount_hash();
+@@ -1973,9 +1995,6 @@
+ 					int flag)
+ {
+ 	struct mount *res, *p, *q, *r, *parent;
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-    bool is_zygote_not_copy_mnt_ns = (susfs_is_current_zygote_domain() && !(flag & CL_COPY_MNT_NS));
+-#endif
+ 
+ 	if (!(flag & CL_COPY_UNBINDABLE) && IS_MNT_UNBINDABLE(mnt))
+ 		return ERR_PTR(-EINVAL);
+@@ -1992,9 +2011,7 @@
+ 	p = mnt;
+ 	list_for_each_entry(r, &mnt->mnt_mounts, mnt_child) {
+ 		struct mount *s;
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-		int attach_mnt_count = 0;
+-#endif
++
+ 		if (!is_subdir(r->mnt_mountpoint, dentry))
+ 			continue;
+ 
+@@ -2024,13 +2041,7 @@
+ 			q = clone_mnt(p, p->mnt.mnt_root, flag);
+ 			if (IS_ERR(q))
+ 				goto out;
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-            if (is_zygote_not_copy_mnt_ns &&
+-				q->mnt_id < DEFAULT_KSU_MNT_ID) {
+-					attach_mnt_count++;
+-					q->mnt_id += attach_mnt_count;
+-			}
+-#endif
++
+ 			lock_mount_hash();
+ 			list_add_tail(&q->mnt_list, &res->mnt_list);
+ 			attach_mnt(q, parent, p->mnt_mp);
+@@ -2497,13 +2508,12 @@
+ 		unlock_mount_hash();
+ 	}
+ #if defined(CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT) || defined(CONFIG_KSU_SUSFS_AUTO_ADD_TRY_UMOUNT_FOR_BIND_MOUNT)
+-	// Check if bind mounted path should be hidden and umounted automatically.
++	// - Check if bind mounted path should be hidden and umounted automatically.
+ 	// And we target only process with ksu domain.
+ 	if (susfs_is_current_ksu_domain()) {
+ #if defined(CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT)
+-		if (susfs_is_auto_add_sus_bind_mount_enabled &&
+-				susfs_auto_add_sus_bind_mount(old_name, &old_path)) {
+-			goto orig_flow;
++		if (susfs_is_auto_add_sus_bind_mount_enabled) {
++			susfs_auto_add_sus_bind_mount(old_name, &old_path);
+ 		}
+ #endif
+ #if defined(CONFIG_KSU_SUSFS_AUTO_ADD_TRY_UMOUNT_FOR_BIND_MOUNT)
+@@ -2512,9 +2522,6 @@
+ 		}
+ #endif
+ 	}
+-#if defined(CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT)
+-orig_flow:
+-#endif
+ #endif // #if defined(CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT) || defined(CONFIG_KSU_SUSFS_AUTO_ADD_TRY_UMOUNT_FOR_BIND_MOUNT)
+ 
+ out2:
+@@ -3193,10 +3200,6 @@
+ 	struct mount *old;
+ 	struct mount *new;
+ 	int copy_flags;
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	bool is_zygote_pid = susfs_is_current_zygote_domain();
+-	int last_entry_mnt_id = 0;
+-#endif
+ 
+ 	BUG_ON(!ns);
+ 
+@@ -3237,12 +3240,7 @@
+ 	 */
+ 	p = old;
+ 	q = new;
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-	if (likely(is_zygote_pid)) {
+-		last_entry_mnt_id = new->mnt_id;
+-		q->mnt.susfs_mnt_id_backup = new->mnt_id;
+-	}
+-#endif
++
+ 	while (p) {
+ 		q->mnt_ns = new_ns;
+ 		new_ns->mounts++;
+@@ -3260,15 +3258,7 @@
+ 		q = next_mnt(q, new);
+ 		if (!q)
+ 			break;
+-#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+-		// Here We are only interested in processes of which original mnt namespace belongs to zygote
+-		if (likely(is_zygote_pid && (q->mnt_id < DEFAULT_KSU_MNT_ID))) {
+-			// q->mnt.susfs_mnt_id_backup -> original mnt_id
+-			// q->mnt_id -> to be modified to the fake mnt_id
+-			q->mnt.susfs_mnt_id_backup = q->mnt_id;
+-			q->mnt_id = ++last_entry_mnt_id;
+-		}
+-#endif
++
+ 		while (p->mnt.mnt_root != q->mnt.mnt_root)
+ 			p = next_mnt(p, old);
+ 	}
+@@ -3356,7 +3346,14 @@
+ 		goto out_data;
+ 
+ 	ret = do_mount(kernel_dev, dir_name, kernel_type, flags, options);
+-
++#ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_KSU_DEFAULT_MOUNT
++	// - We do not check anymore if boot-completed stage is triggered
++	//   just to stop the performance loss
++	// - Just for the compatibility of Magic Mount KernelSU
++	if (!susfs_is_boot_completed_triggered && !ret && susfs_is_auto_add_sus_ksu_default_mount_enabled && susfs_is_current_ksu_domain()) {
++		susfs_auto_add_sus_ksu_default_mount(dir_name);
++	}
++#endif
+ 	kfree(options);
+ out_data:
+ 	kfree(kernel_dev);
+@@ -3820,26 +3817,6 @@
+ 	.owner		= mntns_owner,
+ };
+ 
+-#ifdef CONFIG_KSU_SUSFS_TRY_UMOUNT
+-extern void susfs_try_umount_all(uid_t uid);
+-void susfs_run_try_umount_for_current_mnt_ns(void) {
+-       struct mount *mnt;
+-       struct mnt_namespace *mnt_ns;
+-
+-       mnt_ns = current->nsproxy->mnt_ns;
+-       // Lock the namespace
+-       namespace_lock();
+-       list_for_each_entry(mnt, &mnt_ns->list, mnt_list) {
+-               // Change the sus mount to be private
+-               if (mnt->mnt_id >= DEFAULT_KSU_MNT_ID) {
+-                       change_mnt_propagation(mnt, MS_PRIVATE);
+-               }
+-       }
+-       // Unlock the namespace
+-       namespace_unlock();
+-       susfs_try_umount_all(current_uid().val);
+-}
+-#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+ /* Reorder the mnt_id after all sus mounts are umounted during ksu_handle_setuid() */
+ void susfs_reorder_mnt_id(void) {
+@@ -3854,8 +3831,12 @@
+ 	get_mnt_ns(mnt_ns);
+ 	first_mnt_id = list_first_entry(&mnt_ns->list, struct mount, mnt_list)->mnt_id;
+ 	list_for_each_entry(mnt, &mnt_ns->list, mnt_list) {
+-		mnt->mnt.susfs_mnt_id_backup = mnt->mnt_id;
+-		mnt->mnt_id = first_mnt_id++;
++		// It is very important that we don't reorder the sus mount if it is not umounted
++		if (mnt->mnt_id == DEFAULT_KSU_MNT_ID) {
++			continue;
++		}
++		WRITE_ONCE(mnt->mnt.susfs_mnt_id_backup, READ_ONCE(mnt->mnt_id));
++		WRITE_ONCE(mnt->mnt_id, first_mnt_id++);
+ 	}
+ 	put_mnt_ns(mnt_ns);
+ }
+diff --color -uNr a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
+--- a/fs/proc/task_mmu.c	2025-10-27 03:49:30.000000000 +0800
++++ b/fs/proc/task_mmu.c	2025-10-27 13:24:29.000000000 +0800
+@@ -21,7 +21,7 @@
+ #include <linux/pkeys.h>
+ #include <linux/mm_inline.h>
+ #include <linux/ctype.h>
+-#ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
++#if defined(CONFIG_KSU_SUSFS_SUS_KSTAT) || defined(CONFIG_KSU_SUSFS_SUS_MAP)
+ #include <linux/susfs_def.h>
+ #endif
+ 
+@@ -386,6 +386,24 @@
+ 
+ 	if (file) {
+ 		struct inode *inode = file_inode(vma->vm_file);
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++		if (unlikely(inode->i_mapping->flags & BIT_SUS_MAPS) && susfs_is_current_proc_umounted()) {
++			seq_setwidth(m, 25 + sizeof(void *) * 6 - 1);
++			seq_put_hex_ll(m, NULL, vma->vm_start, 8);
++			seq_put_hex_ll(m, "-", vma->vm_end, 8);
++			seq_putc(m, ' ');
++			seq_putc(m, '-');
++			seq_putc(m, '-');
++			seq_putc(m, '-');
++			seq_putc(m, 'p');
++			seq_put_hex_ll(m, " ", pgoff, 8);
++			seq_put_hex_ll(m, " ", MAJOR(dev), 2);
++			seq_put_hex_ll(m, ":", MINOR(dev), 2);
++			seq_put_decimal_ull(m, " ", ino);
++			seq_putc(m, ' ');
++			goto done;
++		}
++#endif
+ #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+ 		if (unlikely(inode->i_mapping->flags & BIT_SUS_KSTAT)) {
+ 			susfs_sus_ino_for_show_map_vma(inode->i_ino, &dev, &ino);
+@@ -896,13 +914,41 @@
+ 
+ 	memset(&mss, 0, sizeof(mss));
+ 
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++	if (vma->vm_file &&
++		unlikely(file_inode(vma->vm_file)->i_mapping->flags & BIT_SUS_MAPS) &&
++		susfs_is_current_proc_umounted())
++	{
++		smap_gather_stats(vma, &mss);
++
++		show_map_vma(m, vma);
++		if (vma_get_anon_name(vma)) {
++			seq_puts(m, "Name:           ");
++			seq_print_vma_name(m, vma);
++		}
++
++		SEQ_PUT_DEC("Size:           ", vma->vm_end - vma->vm_start);
++		SEQ_PUT_DEC(" kB\nKernelPageSize: ", vma_kernel_pagesize(vma));
++		SEQ_PUT_DEC(" kB\nMMUPageSize:    ", vma_mmu_pagesize(vma));
++		seq_puts(m, " kB\n");
++
++		__show_smap(m, &mss);
++
++		seq_printf(m, "THPeligible:    %d\n", transparent_hugepage_enabled(vma));
++
++		if (arch_pkeys_enabled())
++			seq_printf(m, "ProtectionKey:  %8u\n", vma_pkey(vma));
++
++		goto bypass_orig_flow;
++	}
++#endif
++
+ 	smap_gather_stats(vma, &mss);
+ 
+ 	show_map_vma(m, vma);
+ 	if (vma_get_anon_name(vma)) {
+ 		seq_puts(m, "Name:           ");
+ 		seq_print_vma_name(m, vma);
+-		seq_putc(m, '\n');
+ 	}
+ 
+ 	SEQ_PUT_DEC("Size:           ", vma->vm_end - vma->vm_start);
+@@ -916,6 +962,11 @@
+ 
+ 	if (arch_pkeys_enabled())
+ 		seq_printf(m, "ProtectionKey:  %8u\n", vma_pkey(vma));
++		
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++bypass_orig_flow:
++#endif
++
+ 	show_smap_vma_flags(m, vma);
+ 
+ 	m_cache_vma(m, vma);
+@@ -951,7 +1002,19 @@
+ 	hold_task_mempolicy(priv);
+ 
+ 	for (vma = priv->mm->mmap; vma; vma = vma->vm_next) {
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++		if (vma->vm_file &&
++			unlikely(file_inode(vma->vm_file)->i_mapping->flags & BIT_SUS_MAPS) &&
++			susfs_is_current_proc_umounted())
++		{
++			memset(&mss, 0, sizeof(mss));
++			goto bypass_orig_flow;
++		}
++#endif
+ 		smap_gather_stats(vma, &mss);
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++bypass_orig_flow:
++#endif
+ 		last_vma_end = vma->vm_end;
+ 	}
+ 
+@@ -1604,6 +1667,9 @@
+ 	unsigned long start_vaddr;
+ 	unsigned long end_vaddr;
+ 	int ret = 0, copied = 0;
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++	struct vm_area_struct *vma;
++#endif
+ 
+ 	if (!mm || !mmget_not_zero(mm))
+ 		goto out;
+@@ -1664,6 +1730,15 @@
+ 			goto out_free;
+ 		ret = walk_page_range(start_vaddr, end, &pagemap_walk);
+ 		up_read(&mm->mmap_sem);
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++		vma = find_vma(mm, start_vaddr);
++		if (vma && vma->vm_file) {
++			struct inode *inode = file_inode(vma->vm_file);
++			if (unlikely(inode->i_mapping->flags & BIT_SUS_MAPS) && susfs_is_current_proc_umounted()) {
++				pm.buffer->pme = 0;
++			}
++		}
++#endif
+ 		start_vaddr = end;
+ 
+ 		len = min(count, PM_ENTRY_BYTES * pm.pos);
+diff --color -uNr a/fs/susfs.c b/fs/susfs.c
+--- a/fs/susfs.c	2025-10-27 03:09:26.000000000 +0800
++++ b/fs/susfs.c	2025-10-27 11:16:32.408061589 +0800
+@@ -30,8 +30,8 @@
+ #define SUSFS_LOGI(fmt, ...) if (susfs_is_log_enabled) pr_info("susfs:[%u][%d][%s] " fmt, current_uid().val, current->pid, __func__, ##__VA_ARGS__)
+ #define SUSFS_LOGE(fmt, ...) if (susfs_is_log_enabled) pr_err("susfs:[%u][%d][%s]" fmt, current_uid().val, current->pid, __func__, ##__VA_ARGS__)
+ #else
+-#define SUSFS_LOGI(fmt, ...)
+-#define SUSFS_LOGE(fmt, ...)
++#define SUSFS_LOGI(fmt, ...) 
++#define SUSFS_LOGE(fmt, ...) 
+ #endif
+ 
+ bool susfs_starts_with(const char *str, const char *prefix) {
+@@ -92,7 +92,7 @@
+ 		err = -EINVAL;
+ 		goto out_path_put_path;
+ 	}
+-
++	
+ 	if (cmd == CMD_SUSFS_SET_ANDROID_DATA_ROOT_PATH) {
+ 		spin_lock(&inode->i_lock);
+ 		set_bit(AS_FLAGS_ANDROID_DATA_ROOT_DIR, &inode->i_mapping->flags);
+@@ -137,7 +137,7 @@
+ 		return err;
+ 	}
+ 
+-	err = kern_path(info.target_pathname, LOOKUP_FOLLOW, &path);
++	err = kern_path(info.target_pathname, 0, &path);
+ 	if (err) {
+ 		SUSFS_LOGE("Failed opening file '%s'\n", info.target_pathname);
+ 		return err;
+@@ -458,7 +458,7 @@
+ 	struct inode *inode = NULL;
+ 	int err = 0;
+ 
+-	err = kern_path(target_pathname, 0, &p);
++	err = kern_path(target_pathname, LOOKUP_FOLLOW, &p);
+ 	if (err) {
+ 		SUSFS_LOGE("Failed opening file '%s'\n", target_pathname);
+ 		return;
+@@ -542,26 +542,24 @@
+ }
+ 
+ #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT
+-int susfs_auto_add_sus_bind_mount(const char *pathname, struct path *path_target) {
++void susfs_auto_add_sus_bind_mount(const char *pathname, struct path *path_target) {
+ 	struct mount *mnt;
+ 	struct inode *inode;
+ 
+ 	mnt = real_mount(path_target->mnt);
+ 	if (mnt->mnt_group_id > 0 && // 0 means no peer group
+ 		mnt->mnt_group_id < DEFAULT_KSU_MNT_GROUP_ID) {
+-		SUSFS_LOGE("skip setting SUS_MOUNT inode state for path '%s' since its source mount has a legit peer group id\n", pathname);
+-		// return 0 here as we still want it to be added to try_umount list
+-		return 0;
++		// Just return here
++		return;
+ 	}
+ 	inode = path_target->dentry->d_inode;
+-	if (!inode) return 1;
++	if (!inode) return;
+ 	if (!(inode->i_mapping->flags & BIT_SUS_MOUNT)) {
+ 		spin_lock(&inode->i_lock);
+ 		set_bit(AS_FLAGS_SUS_MOUNT, &inode->i_mapping->flags);
+ 		spin_unlock(&inode->i_lock);
+ 		SUSFS_LOGI("set SUS_MOUNT inode state for source bind mount path '%s'\n", pathname);
+ 	}
+-	return 0;
+ }
+ #endif // #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT
+ 
+@@ -584,8 +582,8 @@
+ 	}
+ 	if ((!strncmp(pathname, "/data/adb/modules", 17) ||
+ 		 !strncmp(pathname, "/debug_ramdisk", 14) ||
+-		 !strncmp(pathname, "/system", 7) ||
+ 		 !strncmp(pathname, "/system_ext", 11) ||
++		 !strncmp(pathname, "/system", 7) ||
+ 		 !strncmp(pathname, "/vendor", 7) ||
+ 		 !strncmp(pathname, "/product", 8) ||
+ 		 !strncmp(pathname, "/odm", 4)) &&
+@@ -621,7 +619,7 @@
+ 	struct inode *inode = NULL;
+ 	int err = 0;
+ 
+-	err = kern_path(target_pathname, LOOKUP_FOLLOW, &p);
++	err = kern_path(target_pathname, 0, &p);
+ 	if (err) {
+ 		SUSFS_LOGE("Failed opening file '%s'\n", target_pathname);
+ 		return 1;
+@@ -878,12 +876,9 @@
+ 
+ #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_TRY_UMOUNT_FOR_BIND_MOUNT
+ void susfs_auto_add_try_umount_for_bind_mount(struct path *path) {
+-	struct st_susfs_try_umount_list *cursor = NULL, *temp = NULL;
+ 	struct st_susfs_try_umount_list *new_list = NULL;
+ 	char *pathname = NULL, *dpath = NULL;
+-#ifdef CONFIG_KSU_SUSFS_HAS_MAGIC_MOUNT
+-	bool is_magic_mount_path = false;
+-#endif
++	size_t new_pathname_len = 0;
+ 
+ #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+ 	if (path->dentry->d_inode->i_mapping->flags & BIT_SUS_KSTAT) {
+@@ -904,43 +899,29 @@
+ 		goto out_free_pathname;
+ 	}
+ 
+-#ifdef CONFIG_KSU_SUSFS_HAS_MAGIC_MOUNT
+-	if (strstr(dpath, MAGIC_MOUNT_WORKDIR)) {
+-		is_magic_mount_path = true;
+-	}
+-#endif
+-
+-	list_for_each_entry_safe(cursor, temp, &LH_TRY_UMOUNT_PATH, list) {
+-#ifdef CONFIG_KSU_SUSFS_HAS_MAGIC_MOUNT
+-		if (is_magic_mount_path && strstr(dpath, cursor->info.target_pathname)) {
+-			goto out_free_pathname;
+-		}
+-#endif
+-		if (unlikely(!strcmp(dpath, cursor->info.target_pathname))) {
+-			SUSFS_LOGE("target_pathname: '%s', ino: %lu, is already created in LH_TRY_UMOUNT_PATH\n",
+-							dpath, path->dentry->d_inode->i_ino);
+-			goto out_free_pathname;
++	// - Important to check if it is from a magic mount, if so, then we need only
++	//   the path which is directory only, others should be skipped.
++	// - We need to strip out "/debug_ramdisk/workdir" here since there will be
++	//   no "/debug_ramdisk/workdir" prefixed in zygote mnt ns
++	if (!strncmp(dpath, "/debug_ramdisk/workdir/", 23)) {
++		if (path->dentry->d_inode && S_ISDIR(path->dentry->d_inode->i_mode)) {
++			new_pathname_len = strlen(dpath) - 22;
++			memmove(dpath, dpath+22, new_pathname_len);
++			*(dpath + new_pathname_len) = '\0';
++			goto add_to_new_list;
+ 		}
++		goto out_free_pathname;
+ 	}
+ 
++add_to_new_list:
+ 	new_list = kmalloc(sizeof(struct st_susfs_try_umount_list), GFP_KERNEL);
+ 	if (!new_list) {
+ 		SUSFS_LOGE("no enough memory\n");
+ 		goto out_free_pathname;
+ 	}
+ 
+-#ifdef CONFIG_KSU_SUSFS_HAS_MAGIC_MOUNT
+-	if (is_magic_mount_path) {
+-		strncpy(new_list->info.target_pathname, dpath + strlen(MAGIC_MOUNT_WORKDIR), SUSFS_MAX_LEN_PATHNAME-1);
+-		goto out_add_to_list;
+-	}
+-#endif
+ 	strncpy(new_list->info.target_pathname, dpath, SUSFS_MAX_LEN_PATHNAME-1);
+ 
+-#ifdef CONFIG_KSU_SUSFS_HAS_MAGIC_MOUNT
+-out_add_to_list:
+-#endif
+-
+ 	new_list->info.mnt_mode = TRY_UMOUNT_DETACH;
+ 
+ 	INIT_LIST_HEAD(&new_list->list);
+@@ -1123,7 +1104,7 @@
+ 	hash_add(OPEN_REDIRECT_HLIST, &new_entry->node, info.target_ino);
+ 	if (update_hlist) {
+ 		SUSFS_LOGI("target_ino: '%lu', target_pathname: '%s', redirected_pathname: '%s', is successfully updated to OPEN_REDIRECT_HLIST\n",
+-				new_entry->target_ino, new_entry->target_pathname, new_entry->redirected_pathname);
++				new_entry->target_ino, new_entry->target_pathname, new_entry->redirected_pathname);	
+ 	} else {
+ 		SUSFS_LOGI("target_ino: '%lu', target_pathname: '%s' redirected_pathname: '%s', is successfully added to OPEN_REDIRECT_HLIST\n",
+ 				new_entry->target_ino, new_entry->target_pathname, new_entry->redirected_pathname);
+@@ -1145,6 +1126,96 @@
+ }
+ #endif // #ifdef CONFIG_KSU_SUSFS_OPEN_REDIRECT
+ 
++/* sus_su */
++#ifdef CONFIG_KSU_SUSFS_SUS_SU
++extern int susfs_sus_su_working_mode;
++extern void ksu_susfs_enable_sus_su(void);
++extern void ksu_susfs_disable_sus_su(void);
++
++int susfs_get_sus_su_working_mode(void) {
++	return susfs_sus_su_working_mode;
++}
++
++int susfs_sus_su(struct st_sus_su* __user user_info) {
++	struct st_sus_su info;
++	int last_working_mode = susfs_sus_su_working_mode;
++
++	if (copy_from_user(&info, user_info, sizeof(struct st_sus_su))) {
++		SUSFS_LOGE("failed copying from userspace\n");
++		return 1;
++	}
++
++	if (info.mode == SUS_SU_WITH_HOOKS) {
++		if (last_working_mode == SUS_SU_WITH_HOOKS) {
++			SUSFS_LOGE("current sus_su mode is already %d\n", SUS_SU_WITH_HOOKS);
++			return 1;
++		}
++		if (last_working_mode != SUS_SU_DISABLED) {
++			SUSFS_LOGE("please make sure the current sus_su mode is %d first\n", SUS_SU_DISABLED);
++			return 2;
++		}
++		ksu_susfs_enable_sus_su();
++		SUSFS_LOGI("core kprobe hooks for ksu are disabled!\n");
++		SUSFS_LOGI("non-kprobe hook sus_su is enabled!\n");
++		SUSFS_LOGI("sus_su mode: %d\n", SUS_SU_WITH_HOOKS);
++		return 0;
++	} else if (info.mode == SUS_SU_DISABLED) {
++		if (last_working_mode == SUS_SU_DISABLED) {
++			SUSFS_LOGE("current sus_su mode is already %d\n", SUS_SU_DISABLED);
++			return 1;
++		}
++		ksu_susfs_disable_sus_su();
++		if (last_working_mode == SUS_SU_WITH_HOOKS) {
++			SUSFS_LOGI("core kprobe hooks for ksu are enabled!\n");
++			goto out;
++		}
++out:
++		if (copy_to_user(user_info, &info, sizeof(info)))
++			SUSFS_LOGE("copy_to_user() failed\n");
++		return 0;
++	} else if (info.mode == SUS_SU_WITH_OVERLAY) {
++		SUSFS_LOGE("sus_su mode %d is deprecated\n", SUS_SU_WITH_OVERLAY);
++		return 1;
++	}
++	return 1;
++}
++#endif // #ifdef CONFIG_KSU_SUSFS_SUS_SU
++
++/* sus_map */
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++int susfs_add_sus_map(struct st_susfs_sus_map* __user user_info) {
++	struct st_susfs_sus_map info;
++	struct path path;
++	struct inode *inode = NULL;
++	int err = 0;
++
++	err = copy_from_user(&info, user_info, sizeof(info));
++	if (err) {
++		SUSFS_LOGE("failed copying from userspace\n");
++		return err;
++	}
++
++	err = kern_path(info.target_pathname, LOOKUP_FOLLOW, &path);
++	if (err) {
++		SUSFS_LOGE("Failed opening file '%s'\n", info.target_pathname);
++		return err;
++	}
++
++	if (!path.dentry->d_inode) {
++		err = -EINVAL;
++		goto out_path_put_path;
++	}
++	inode = d_inode(path.dentry);
++	spin_lock(&inode->i_lock);
++	set_bit(AS_FLAGS_SUS_MAP, &inode->i_mapping->flags);
++	SUSFS_LOGI("pathname: '%s', is flagged as AS_FLAGS_SUS_MAP\n", info.target_pathname);
++	spin_unlock(&inode->i_lock);
++out_path_put_path:
++	path_put(&path);
++	return err;
++}
++#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MAP
++
+ static int copy_config_to_buf(const char *config_string, char *buf_ptr, size_t *copied_size, size_t bufsize) {
+ 	size_t tmp_size = strlen(config_string);
+ 
+@@ -1233,8 +1304,8 @@
+ 	if (err) goto out_kfree_kbuf;
+ 	buf_ptr = kbuf + copied_size;
+ #endif
+-#ifdef CONFIG_KSU_SUSFS_HAS_MAGIC_MOUNT
+-	err = copy_config_to_buf("CONFIG_KSU_SUSFS_HAS_MAGIC_MOUNT\n", buf_ptr, &copied_size, bufsize);
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++	err = copy_config_to_buf("CONFIG_KSU_SUSFS_SUS_MAP\n", buf_ptr, &copied_size, bufsize);
+ 	if (err) goto out_kfree_kbuf;
+ 	buf_ptr = kbuf + copied_size;
+ #endif
+diff --color -uNr a/include/linux/susfs.h b/include/linux/susfs.h
+--- a/include/linux/susfs.h	2025-10-27 06:37:36.000000000 +0800
++++ b/include/linux/susfs.h	2025-10-26 21:59:00.000000000 +0800
+@@ -8,7 +8,7 @@
+ #include <linux/path.h>
+ #include <linux/susfs_def.h>
+ 
+-#define SUSFS_VERSION "v1.5.11"
++#define SUSFS_VERSION "v1.5.12"
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+ #define SUSFS_VARIANT "NON-GKI"
+ #else
+@@ -29,7 +29,7 @@
+ struct st_susfs_sus_path {
+ 	unsigned long                    target_ino;
+ 	char                             target_pathname[SUSFS_MAX_LEN_PATHNAME];
+-	unsigned int					 i_uid;
++	unsigned int                     i_uid;
+ };
+ 
+ struct st_susfs_sus_path_list {
+@@ -127,6 +127,20 @@
+ };
+ #endif
+ 
++/* sus_su */
++#ifdef CONFIG_KSU_SUSFS_SUS_SU
++struct st_sus_su {
++	int         mode;
++};
++#endif
++
++/* sus_map */
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++struct st_susfs_sus_map {
++	char                             target_pathname[SUSFS_MAX_LEN_PATHNAME];
++};
++#endif
++
+ /***********************/
+ /* FORWARD DECLARATION */
+ /***********************/
+@@ -138,12 +152,6 @@
+ /* sus_mount */
+ #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+ int susfs_add_sus_mount(struct st_susfs_sus_mount* __user user_info);
+-#ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT
+-int susfs_auto_add_sus_bind_mount(const char *pathname, struct path *path_target);
+-#endif // #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_BIND_MOUNT
+-#ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_KSU_DEFAULT_MOUNT
+-void susfs_auto_add_sus_ksu_default_mount(const char __user *to_pathname);
+-#endif // #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_SUS_KSU_DEFAULT_MOUNT
+ #endif // #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+ 
+ /* sus_kstat */
+@@ -157,9 +165,6 @@
+ #ifdef CONFIG_KSU_SUSFS_TRY_UMOUNT
+ int susfs_add_try_umount(struct st_susfs_try_umount* __user user_info);
+ void susfs_try_umount(uid_t target_uid);
+-#ifdef CONFIG_KSU_SUSFS_AUTO_ADD_TRY_UMOUNT_FOR_BIND_MOUNT
+-void susfs_auto_add_try_umount_for_bind_mount(struct path *path);
+-#endif // #ifdef CONFIG_KSU_SUSFS_AUTO_ADD_TRY_UMOUNT_FOR_BIND_MOUNT
+ #endif // #ifdef CONFIG_KSU_SUSFS_TRY_UMOUNT
+ /* spoof_uname */
+ #ifdef CONFIG_KSU_SUSFS_SPOOF_UNAME
+@@ -180,6 +185,15 @@
+ int susfs_add_open_redirect(struct st_susfs_open_redirect* __user user_info);
+ struct filename* susfs_get_redirected_path(unsigned long ino);
+ #endif
++/* sus_su */
++#ifdef CONFIG_KSU_SUSFS_SUS_SU
++int susfs_get_sus_su_working_mode(void);
++int susfs_sus_su(struct st_sus_su* __user user_info);
++#endif
++/* sus_map */
++#ifdef CONFIG_KSU_SUSFS_SUS_MAP
++int susfs_add_sus_map(struct st_susfs_sus_map* __user user_info);
++#endif
+ 
+ int susfs_get_enabled_features(char __user* buf, size_t bufsize);
+ void susfs_set_avc_log_spoofing(bool enabled);
+diff --color -uNr a/include/linux/susfs_def.h b/include/linux/susfs_def.h
+--- a/include/linux/susfs_def.h	2025-10-27 03:09:26.000000000 +0800
++++ b/include/linux/susfs_def.h	2025-10-26 21:59:00.000000000 +0800
+@@ -25,7 +25,11 @@
+ #define CMD_SUSFS_SHOW_VERSION 0x555e1
+ #define CMD_SUSFS_SHOW_ENABLED_FEATURES 0x555e2
+ #define CMD_SUSFS_SHOW_VARIANT 0x555e3
++#define CMD_SUSFS_SHOW_SUS_SU_WORKING_MODE 0x555e4
++#define CMD_SUSFS_IS_SUS_SU_READY 0x555f0
++#define CMD_SUSFS_SUS_SU 0x60000
+ #define CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING 0x60010
++#define CMD_SUSFS_ADD_SUS_MAP 0x60020
+ 
+ #define SUSFS_MAX_LEN_PATHNAME 256 // 256 should address many paths already unless you are doing some strange experimental stuff, then set your own desired length
+ #define SUSFS_FAKE_CMDLINE_OR_BOOTCONFIG_SIZE 4096
+@@ -33,15 +37,21 @@
+ #define TRY_UMOUNT_DEFAULT 0 /* used by susfs_try_umount() */
+ #define TRY_UMOUNT_DETACH 1 /* used by susfs_try_umount() */
+ 
+-#define DEFAULT_KSU_MNT_ID 300000 /* used by mount->mnt_id */
+-#define DEFAULT_KSU_MNT_ID_FOR_KSU_PROC_UNSHARE 1000000 /* used by vfsmount->susfs_mnt_id_backup */
+-#define DEFAULT_KSU_MNT_GROUP_ID 3000 /* used by mount->mnt_group_id */
++#define SUS_SU_DISABLED 0
++#define SUS_SU_WITH_OVERLAY 1 /* deprecated */
++#define SUS_SU_WITH_HOOKS 2
++
++#define DEFAULT_KSU_MNT_ID 500000 /* used by mount->mnt_id */
++#define DEFAULT_KSU_MNT_GROUP_ID 5000 /* used by mount->mnt_group_id */
+ 
+ /*
+- * mount->mnt.susfs_mnt_id_backup => storing original mnt_id of normal mounts or custom sus mnt_id of sus mounts
+- * task_struct->susfs_task_state => storing flag 'TASK_STRUCT_'
++ * mount->mnt.susfs_mnt_id_backup => storing original mount's mnt_id
++ * inode->i_mapping->flags => storing flag 'AS_FLAGS_'
++ * nd->state => storing flag 'ND_STATE_'
++ * nd->flags => storing flag 'ND_FLAGS_'
++ * task_struct->thread_info.flags => storing flag 'TIF_'
+  */
+-
++ // thread_info->flags is unsigned long :D
+ #define TIF_PROC_UMOUNTED 33
+ 
+ #define AS_FLAGS_SUS_PATH 24
+@@ -50,18 +60,20 @@
+ #define AS_FLAGS_OPEN_REDIRECT 27
+ #define AS_FLAGS_ANDROID_DATA_ROOT_DIR 28
+ #define AS_FLAGS_SDCARD_ROOT_DIR 29
++#define AS_FLAGS_SUS_MAP 30
+ #define BIT_SUS_PATH BIT(24)
+ #define BIT_SUS_MOUNT BIT(25)
+ #define BIT_SUS_KSTAT BIT(26)
+ #define BIT_OPEN_REDIRECT BIT(27)
+ #define BIT_ANDROID_DATA_ROOT_DIR BIT(28)
+ #define BIT_ANDROID_SDCARD_ROOT_DIR BIT(29)
++#define BIT_SUS_MAPS BIT(30)
+ 
+ #define ND_STATE_LOOKUP_LAST 32
+ #define ND_STATE_OPEN_LAST 64
+ #define ND_STATE_LAST_SDCARD_SUS_PATH 128
+ #define ND_FLAGS_LOOKUP_LAST		0x2000000
+-
++ 
+ #define MAGIC_MOUNT_WORKDIR "/debug_ramdisk/workdir"
+ #define DATA_ADB_UMOUNT_FOR_ZYGOTE_SYSTEM_PROCESS "/data/adb/susfs_umount_for_zygote_system_process"
+ #define DATA_ADB_NO_AUTO_ADD_SUS_BIND_MOUNT "/data/adb/susfs_no_auto_add_sus_bind_mount"
+@@ -75,5 +87,4 @@
+ static inline void susfs_set_current_proc_umounted(void) {
+ 	set_ti_thread_flag(&current->thread_info, TIF_PROC_UMOUNTED);
+ }
+-
+ #endif // #ifndef KSU_SUSFS_DEF_H


### PR DESCRIPTION
**Tracked from susfs branch android13-5.10,Adapt to k4.19**
- The patch is based on [Redmi 8 kernel](https://github.com/JackA1ltman/android_kernel_xiaomi_sdm439-4.19)

**Reference was made to the following documents**
- https://github.com/rsuntk/android_kernel_asus_sdm660/commit/6301ac2e7f4f732d4b5048aa68e95ee0a1543cf9
- https://gitlab.com/simonpunk/susfs4ksu/-/commit/e5c9eabfc6dcfc677d11f46ce1d5ff786de60a92
- https://github.com/yu13140/android_kernel_xiaomi_sdm660_419/commit/8c264f7a984e21478986890c57987916e59efa5f

Change-Id: Ia511d91bf7028f5a92d6cb1a3798742936ffea04