### PR TITLE
Fix kernelsu hook not applying for veux.

### DIFF
--- a/.github/workflows/build-redmi-note11pro-5g-aosp-a16.yml
+++ b/.github/workflows/build-redmi-note11pro-5g-aosp-a16.yml
@@ -107,11 +107,11 @@ jobs:
       - name: ⚙️ Get neccssary tools
         uses: ./.github/workflows/build-ready
 
-      - name: 🪝 Patch Kernel of SUSFS
-        uses: ./.github/workflows/patch-susfs
-
       - name: 🔗 Patch for no-kprobe
         uses: ./.github/workflows/patch-no-kprobe
+
+      - name: 🪝 Patch Kernel of SUSFS
+        uses: ./.github/workflows/patch-susfs
 
       - name: 🪛 Extra Kernel Options
         run: |


### PR DESCRIPTION
This also fixes the syscall patch not applying correctly and failing to grant root access on sukisu 4.0.0.