### PR TITLE
Fix path handling for AOSP clang (android.googlesource.com)

### DIFF
--- a/.github/workflows/build-env/action.yml
+++ b/.github/workflows/build-env/action.yml
@@ -494,6 +494,12 @@ runs:
                 ${{ env.CURLX }} "${{ env.CLANG_SOURCE }}" antman
                 chmod +x antman
                 bash antman -S
+            elif [[ "${{ env.CLANG_SOURCE }}" == *"android.googlesource.com"* ]]; then
+                git clone "${{ env.CLANG_SOURCE }}" -b "${{ env.CLANG_BRANCH }}" clang-custom --depth=1
+                SUBDIR=$(find clang-custom -maxdepth 1 -type d -name 'clang-r*' | head -n 1)
+                if [ -n "$SUBDIR" ]; then
+                 mv "$SUBDIR"/* clang-custom/
+                fi    
             else
                 echo ">>>>>>>>>>Clang Status<<<<<<<<<<"
                 echo ">                              <"


### PR DESCRIPTION
由于 AOSP 预编译 clang 存在 clang-rxxxx 子目录，当前 workflow 无法正确识别 clang-custom/bin，从而导致我编译时踩坑。 本补丁自动展开该子目录，确保 clang 能被正确加入 PATH，从而兼容 AOSP clang 源。