### PR TITLE
reboot: sanitize KSU/SUSFS hook to prevent reboot delay and unsafe flow

### DIFF
--- a/Patches/susfs_inline_hook_patches.sh
+++ b/Patches/susfs_inline_hook_patches.sh
@@ -262,8 +262,18 @@ for i in "${patch_files[@]}"; do
     # kernel/ changes
     ## reboot.c
     kernel/reboot.c)
-        sed -i '/SYSCALL_DEFINE4(reboot, int, magic1, int, magic2, unsigned int, cmd,/i \#ifdef CONFIG_KSU\n\extern int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd, void __user **arg);\n\#endif' kernel/reboot.c
-        sed -i '/int ret = 0;/a #ifdef CONFIG_KSU_SUSFS\n    ret = ksu_handle_sys_reboot(magic1, magic2, cmd, \&arg);\n    if (ret) {\n        goto orig_flow;\n    }\n    return ret;\norig_flow:\n#endif' kernel/reboot.c
+        sed -i '/SYSCALL_DEFINE4(reboot, int, magic1, int, magic2, unsigned int, cmd,/i\
+#ifdef CONFIG_KSU_SUSFS\
+extern int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd, void __user **arg);\
+#endif\
+' kernel/reboot.c
+        sed -i '/int ret = 0;/a\
+#ifdef CONFIG_KSU_SUSFS\
+    if (system_state == SYSTEM_RUNNING) {\
+        ksu_handle_sys_reboot(magic1, magic2, cmd, \&arg);\
+    }\
+#endif\
+' kernel/reboot.c
 
         if grep -q "ksu_handle_sys_reboot" "kernel/reboot.c"; then
             echo "[+] kernel/reboot.c Patched!"

--- a/Patches/syscall_hook_patches.sh
+++ b/Patches/syscall_hook_patches.sh
@@ -261,8 +261,18 @@ for i in "${patch_files[@]}"; do
         if grep -rq --include="*.c" --include="*.h" "ksu_handle_sys_reboot" "drivers/kernelsu/" >/dev/null 2>&1; then
             echo "[+] Checked ksu_handle_sys_reboot existed in KernelSU!"
 
-            sed -i '/SYSCALL_DEFINE4(reboot, int, magic1, int, magic2, unsigned int, cmd,/i\#ifdef CONFIG_KSU\nextern int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd, void __user **arg);\n#endif\n' kernel/reboot.c
-            sed -i '/if (!ns_capable(pid_ns->user_ns, CAP_SYS_BOOT))/i\#ifdef CONFIG_KSU\n\tksu_handle_sys_reboot(magic1, magic2, cmd, \&arg);\n#endif\n' kernel/reboot.c
+            sed -i '/SYSCALL_DEFINE4(reboot, int, magic1, int, magic2, unsigned int, cmd,/i\
+#ifdef CONFIG_KSU\
+extern int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd, void __user **arg);\
+#endif\
+' kernel/reboot.c
+            sed -i '/if (!ns_capable(pid_ns->user_ns, CAP_SYS_BOOT))/i\
+#ifdef CONFIG_KSU\
+\tif (system_state == SYSTEM_RUNNING) {\
+\t\tksu_handle_sys_reboot(magic1, magic2, cmd, \&arg);\
+\t}\
+#endif\
+' kernel/reboot.c
 
             if grep -q "ksu_handle_sys_reboot" "kernel/reboot.c"; then
                 echo "[+] kernel/reboot.c Patched!"


### PR DESCRIPTION
Unify and fix multiple KSU/SUSFS reboot hook implementations that previously introduced delays and unsafe control flow.

Some variants unconditionally invoked ksu_handle_sys_reboot() during reboot, including in recovery and non-running states, leading to noticeable delays (~50s) due to blocking behavior inside the handler.

Other variants modified syscall flow using return and goto, which could interfere with the normal reboot sequence and introduce unintended side effects.

Fix by:
- guarding hook execution with system_state == SYSTEM_RUNNING
- removing direct control flow manipulation (return/goto)
- ensuring the handler is only invoked in valid runtime context

This preserves SUSFS functionality during normal operation while avoiding delays and instability in recovery and shutdown paths.