### PR TITLE
fs/proc: fix critical format string bug and syntax errors in SUSFS cmdline spoofing

### DIFF
--- a/Patches/Patch/susfs_patch_to_4.14.patch
+++ b/Patches/Patch/susfs_patch_to_4.14.patch
@@ -893,7 +893,7 @@ index 0495111..e86c03f 100644
  				continue;
  
 diff --git a/fs/proc/cmdline.c b/fs/proc/cmdline.c
-index 403cbb1..aed87b4 100644
+index 403cbb1..974c2ea 100644
 --- a/fs/proc/cmdline.c
 +++ b/fs/proc/cmdline.c
 @@ -4,8 +4,20 @@
@@ -910,7 +910,7 @@ index 403cbb1..aed87b4 100644
 +#ifdef CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
 +	if (static_branch_likely(&susfs_is_fake_cmdline_or_bootconfig_buffer_set)) {
 +		susfs_spoof_cmdline_or_bootconfig(m);
-+		seq_printf(m, "%s\n");
++		seq_putc(m, '\n');
 +		return 0;
 +	}
 +#endif

--- a/Patches/Patch/susfs_patch_to_4.9.patch
+++ b/Patches/Patch/susfs_patch_to_4.9.patch
@@ -902,7 +902,7 @@ index 3f4c8f1..5bfa27c 100644
  				continue;
  
 diff --git a/fs/proc/cmdline.c b/fs/proc/cmdline.c
-index 57d2d15..9d1dc4b 100644
+index 57d2d15..aa620c1 100644
 --- a/fs/proc/cmdline.c
 +++ b/fs/proc/cmdline.c
 @@ -6,6 +6,11 @@
@@ -924,9 +924,9 @@ index 57d2d15..9d1dc4b 100644
 +#ifdef CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
 +	if (static_branch_likely(&susfs_is_fake_cmdline_or_bootconfig_buffer_set)) {
 +		susfs_spoof_cmdline_or_bootconfig(m);
-+		seq_printf(m, "%s\n");
-+		return 0;
-+	}
++        seq_putc(m, '\n');
++        return 0;
++    }
 +#endif
  #ifdef CONFIG_INITRAMFS_IGNORE_SKIP_FLAG
  	seq_printf(m, "%s\n", proc_command_line);


### PR DESCRIPTION
This reverts commit 364ee97f8de6a7e3de66b0d999edaa8e9a4e46e9.

Fix a critical undefined behavior bug introduced in the SUSFS cmdline 
spoofing hooks for both kernel 4.9 and 4.14 patches.

In both patches, 'seq_printf(m, "%s\n");' was invoked without providing
a matching string argument. This leads to a format string vulnerability,
arbitrary memory reading, or an immediate kernel panic when the static 
branch is triggered.


Signed-off-by: xmanweb <xmanweb@gmail.com>