### PR TITLE
Handle alternate fs/stat.c include layouts

### DIFF
--- a/Patches/susfs_inline_hook_patches.sh
+++ b/Patches/susfs_inline_hook_patches.sh
@@ -113,7 +113,11 @@ for i in "${patch_files[@]}"; do
         if grep -q "unistd" "fs/stat.c" && ! grep -q "susfs_def.h" "fs/stat.c"; then
             sed -i '/#include <asm\/unistd.h>/a\#ifdef CONFIG_KSU_SUSFS\n#include <linux\/susfs_def.h>\n#endif' fs/stat.c
         elif ! grep -q "susfs_def.h" "fs/stat.c"; then
-            sed -i '/#include <asm\/uaccess.h>/i #ifdef CONFIG_KSU_SUSFS\n#include <linux\/susfs_def.h>\n#endif' fs/stat.c
+            if grep -q "vmalloc.h" "fs/stat.c"; then
+                sed -i '/#include <linux\/vmalloc.h>/a\#ifdef CONFIG_KSU_SUSFS\n#include <linux\/susfs_def.h>\n#endif' fs/stat.c
+            else
+                sed -i '/#include <asm\/uaccess.h>/i #ifdef CONFIG_KSU_SUSFS\n#include <linux\/susfs_def.h>\n#endif' fs/stat.c
+            fi
         fi
 
         if grep -q "vfs_statx_fd" "fs/stat.c"; then


### PR DESCRIPTION
The inline hook code added to fs/stat.c calls susfs_is_current_proc_no_su() which requires <linux/susfs_def.h>. The existing fallback only checked for asm/uaccess.h, which may not exist in all kernel trees (e.g. 4.19 uses asm/unistd.h). Add vmalloc.h as an additional fallback anchor, matching the approach used in the exec.c patch section.

This fixes build failures on kernels where neither unistd.h nor uaccess.h are present as include anchors in fs/stat.c.